### PR TITLE
Added MKDocs documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,17 @@
+name: Publish docs via GitHub Pages
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v2
+      - name: Deploy docs
+        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONFIG_FILE: docs-site/mkdocs.yml

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -1,0 +1,22 @@
+# Introduction to DNS Tool
+
+DNS Tool is a command-line utility for network administrators, security researchers, and IT professionals. It simplifies the verification of DNS records like DMARC, SPF, DKIM, and DNSSEC, providing real-time feedback to enhance email security and prevent spoofing.
+
+## Main Features
+
+- **Comprehensive DNS Checks**: Access all key DNS records in one place: NS, A/AAAA, MX, TXT, SPF, DMARC, DKIM, and more. 🌐
+- **Interactive & Batch Modes**: Use an interactive prompt with arrow-key history or batch mode for multiple domains. 🔄
+- **Colorful Output**: Identify issues quickly with highlights using ✅, ❌, ⚠️ for clear guidance.
+
+## Quick Start Guide
+
+### Installation
+
+#### Linux
+1. Download the `dnstool` binary from [GitHub Releases](https://github.com/careyjames/dns-tool/releases).
+2. Make the file executable: `chmod +x dnstool`
+3. Run it: `./dnstool`
+
+Visit the [Installation and Setup](/dns-tool/installation-and-setup.html) page for instructions on other operating systems.
+
+Start using DNS Tool by visiting the [Getting Started](/dns-tool/usage-and-examples.html) guide.

--- a/docs-site/docs/installation-and-setup.md
+++ b/docs-site/docs/installation-and-setup.md
@@ -1,0 +1,45 @@
+# Installation and Setup
+
+Welcome to the **Installation and Setup** guide for the DNS Tool, a command-line utility for DNS and email security validation. Follow these steps to get DNS Tool running on your Linux, macOS, or Windows machine.
+
+## Linux 
+
+1. **Download** the `dnstool` binary from the [GitHub Releases](https://github.com/careyjames/dns-tool/releases).
+2. **Make the binary executable**:  
+   ```bash
+   chmod +x dnstool
+   ```
+3. **Run the tool**:  
+   ```bash
+   ./dnstool
+   ```
+4. Optional: Move the binary to a directory in your PATH:  
+   ```bash
+   sudo mv dnstool /usr/local/bin
+   ```
+
+## macOS
+
+1. **Download** `dnstool_macos` from the [Releases](https://github.com/careyjames/dns-tool/releases).
+2. **Allow execution** via Terminal:  
+   ```bash
+   chmod +x dnstool_macos
+   xattr -r -d com.apple.quarantine ./dnstool_macos
+   ```
+3. **Run**:  
+   ```bash
+   ./dnstool_macos
+   ```
+
+Alternatively, right-click in Finder → Open → Click Open Anyway via Security & Privacy settings.
+
+## Windows
+
+1. **Download** `dnstool.exe` from the [Releases](https://github.com/careyjames/dns-tool/releases).
+2. **Execute** in Command Prompt / PowerShell:  
+   ```powershell
+   .\dnstool.exe
+   ```
+3. If warned by SmartScreen, click "More info → Run anyway."
+
+You are now ready to use DNS Tool, see the [Getting Started guide](/docs-site/usage-and-examples) for next steps.

--- a/docs-site/docs/usage-and-examples.md
+++ b/docs-site/docs/usage-and-examples.md
@@ -1,0 +1,67 @@
+# Usage and Examples
+
+This guide will show you how to get started with DNS Tool. It will showcase how to use the tool in both interactive and batch modes, with example commands and output descriptions.
+
+## Interactive Mode 🌟
+
+Interactive mode is straightforward to use. To enter this mode, run the following command:
+
+```bash
+./dnstool
+```
+
+You’ll see a prompt where you can enter a domain, press Enter, and DNS Tool will perform a DNS check. 
+
+The output is color-coded: ✅ for success, ❌ for failure, and ⚠️ for warnings.
+
+### Example Command
+Run `./dnstool` to start the interactive mode:
+```bash
+./dnstool
+```
+
+Then just enter a domain:
+
+```
+Domain:
+example.com
+```
+
+You will then get color-coded output, such as:
+```
+✅ NS: OK
+❌ SPF: Missing
+⚠️ DMARC: p=none
+```
+
+This design can help to quickly spot configuration issues.
+
+## Batch Mode 🚀
+
+Batch mode allows you to check multiple domains simultaneously. Provide domain names as command-line arguments or via a file.
+
+### Direct Command-line Arguments
+
+```bash
+./dnstool example.com example.org
+```
+
+### File Input
+
+```bash
+./dnstool -f domains.txt
+```
+
+This mode is ideal for managing multiple domains or integrating checks into workflows.
+
+## Verbose Output 🛠️
+
+For detailed insights, use the `-v` flag for verbose output.
+
+```bash
+./dnstool -v example.com
+```
+
+This provides detailed debug information, useful for troubleshooting or understanding the tool’s processes.
+
+For full details and features, refer to the main documentation [here](https://github.com/careyjames/dns-tool).

--- a/docs-site/mkdocs.yml
+++ b/docs-site/mkdocs.yml
@@ -1,0 +1,35 @@
+site_name: Docs page
+site_url: https://careyjames.github.io/dns-tool
+repo_url: https://github.com//careyjames/dns-tool
+repo_name: /careyjames/dns-tool
+nav:
+  - Home: index.md
+  - Installation and Setup: installation-and-setup.md
+  - Usage and Examples: usage-and-examples.md
+
+theme:
+  name: material
+  font:
+    text: Inter
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.footer


### PR DESCRIPTION
Hi Carey,
I've created a documentation site using MKDocs for dns-tool. I've also added a GitHub Action which automatically builds the site and pushes it to the `gh-pages` branch. If you'd like to publish it via GitHub Pages, this can be enabled via the Settings (just click Pages and then 'Deploy from a branch'. If you select the `gh-pages` branch, it will then be published.

The documentation includes:

- Introduction
- Installation steps
- Usage guide

Let me know if you would like any edits, I'm glad to help!