### PR TITLE
Handle verbose logging flag

### DIFF
--- a/dnstool.py
+++ b/dnstool.py
@@ -573,6 +573,9 @@ def main():
     parser.add_argument("domains", nargs="*", help="Domains to check")
     args = parser.parse_args()
 
+    log_level = logging.ERROR if args.verbose else logging.CRITICAL
+    logging.getLogger().setLevel(log_level)
+
     VERBOSE = args.verbose
     if args.resolver:
         RESOLVERS = args.resolver


### PR DESCRIPTION
## Summary
- set log level based on `-v` flag

## Testing
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement pytest)*
- `python - <<'EOF' > /tmp/out_no_v_after.txt 2>&1 ... EOF`
- `python - <<'EOF' > /tmp/out_v_after.txt 2>&1 ... EOF`
