### PR TITLE
Add authoritative DNS lookup option

### DIFF
--- a/tests/test_dnstool.py
+++ b/tests/test_dnstool.py
@@ -43,3 +43,36 @@ def test_validate_domain_valid():
 ])
 def test_validate_domain_invalid(dom):
     assert not dnstool.validate_domain(dom)
+
+
+def test_authoritative_lookup(monkeypatch):
+    # prepare fake dns_query responses
+    query_map = {
+        ("NS", "example.com"): ["ns1.example.com"],
+        ("A", "ns1.example.com"): ["192.0.2.1"],
+        ("AAAA", "ns1.example.com"): [],
+    }
+
+    def fake_dns_query(rdtype, domain):
+        return query_map.get((rdtype, domain), [])
+
+    class DummyResolver:
+        def __init__(self, configure=False):
+            self.nameservers = []
+            self.timeout = None
+            self.lifetime = None
+
+        def resolve(self, domain, rdtype):
+            key = (self.nameservers[0], domain, rdtype)
+            data = {
+                ("192.0.2.1", "example.com", "A"): ["93.184.216.34"],
+                ("192.0.2.1", "example.com", "MX"): ["10 mail.example.com"],
+            }
+            return data.get(key, [])
+
+    monkeypatch.setattr(dnstool, "dns_query", fake_dns_query)
+    monkeypatch.setattr(dnstool.dns.resolver, "Resolver", DummyResolver)
+
+    out = dnstool.authoritative_lookup("example.com", ["A", "MX"])
+    assert out["A"] == ["93.184.216.34"]
+    assert out["MX"] == ["10 mail.example.com"]


### PR DESCRIPTION
## Summary
- add new `--authoritative` CLI option
- implement helper to query authoritative name servers
- display concise authoritative results in `run_all_checks`
- add unit test for `authoritative_lookup`

## Testing
- `python -m py_compile dnstool.py tests/test_dnstool.py`
- *tests require pytest which was unavailable in the environment*