### PR TITLE
Fix Python version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: python -m pip install --upgrade pip pyinstaller -r requirements.txt


### PR DESCRIPTION
## Summary
- use Python `3.12` for the release action

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement requests<3.0)*