### PR TITLE
Improve domain validation

### DIFF
--- a/dnstool.py
+++ b/dnstool.py
@@ -90,6 +90,9 @@ def domain_to_ascii(domain: str) -> str:
 def validate_domain(d: str) -> bool:
     """Return ``True`` if ``d`` looks like a valid domain name."""
     pattern = r"^[A-Za-z0-9._-]+\.[A-Za-z0-9-]{2,}$"
+    if not d or d.startswith(".") or d.endswith(".") or d.endswith("-"):
+        print(f"{SYM_ERR} {RED}Invalid domain:{NC} {d}")
+        return False
     if not re.match(pattern, d):
         print(f"{SYM_ERR} {RED}Invalid domain:{NC} {d}")
         return False

--- a/tests/test_dnstool.py
+++ b/tests/test_dnstool.py
@@ -42,6 +42,8 @@ def test_validate_domain_valid():
     'bad_domain!.com',
     'domain.c',
     '.leading.com',
+    'example.com.',
+    'example.com-',
     ''
 ])
 def test_validate_domain_invalid(dom):


### PR DESCRIPTION
## Summary
- enhance `validate_domain` with simple prefix/suffix checks
- add tests for trailing dot and hyphen cases

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*