### PR TITLE
Add Resolver stub for tests

### DIFF
--- a/tests/test_dnstool.py
+++ b/tests/test_dnstool.py
@@ -9,7 +9,9 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 # dependencies such as requests or dnspython. These tests only exercise
 # helper functions that do not require network access.
 sys.modules.setdefault('requests', types.SimpleNamespace())
-dns_stub = types.SimpleNamespace(resolver=types.SimpleNamespace())
+dns_stub = types.SimpleNamespace(
+    resolver=types.SimpleNamespace(Resolver=None)
+)
 sys.modules.setdefault('dns', dns_stub)
 sys.modules.setdefault('dns.resolver', dns_stub.resolver)
 


### PR DESCRIPTION
## Summary
- ensure the dummy dns resolver stub defines a `Resolver` attribute

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*