### PR TITLE
Fix release upload paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,12 @@ jobs:
         run: pyinstaller --onefile dnstool.py --clean
 
       - name: Rename artefact
-        run: mv dist/dnstool${{ matrix.ext }} dnstool-${{ matrix.target }}-${GITHUB_REF_NAME}${{ matrix.ext }}
+        run: |
+          mv dist/dnstool${{ matrix.ext }} \
+             dnstool-${{ matrix.target }}-${{ github.ref_name }}${{ matrix.ext }}
         shell: bash
 
       - uses: softprops/action-gh-release@v2
         with:
-          files: dnstool-${{ matrix.target }}-${GITHUB_REF_NAME}${{ matrix.ext }}
+          files: dnstool-${{ matrix.target }}-${{ github.ref_name }}${{ matrix.ext }}
           generate_release_notes: true


### PR DESCRIPTION
## Summary
- use `${{ github.ref_name }}` when renaming artifacts and uploading to the release

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*