### PR TITLE
Fix docs workflow path

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,9 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONFIG_FILE: docs-site/mkdocs.yml
+          MKDOCS_BUILD_DIR: docs-site


### PR DESCRIPTION
## Summary
- ensure the documentation workflow uses the mkdocs deploy action
- reference the mkdocs configuration in `docs-site`

## Testing
- `pytest -q` *(fails: `pytest` not installed)*