### PR TITLE
Fix docs workflow action versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v4
       - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        uses: mhausenblas/mkdocs-deploy-gh-pages@v1.29
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONFIG_FILE: docs-site/mkdocs.yml


### PR DESCRIPTION
## Summary
- pin `mhausenblas/mkdocs-deploy-gh-pages` to `v1.29`
- confirm `checkout` action uses `v4`

## Testing
- `pytest -q` *(fails: `pytest` not installed)*