### PR TITLE
Fix newline in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,3 +18,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONFIG_FILE: docs-site/mkdocs.yml
           MKDOCS_BUILD_DIR: docs-site
+


### PR DESCRIPTION
## Summary
- append a blank line to ensure `.github/workflows/docs.yml` ends with a newline

## Testing
- `pip install -r requirements.txt` *(fails: cannot connect to proxy)*