### PR TITLE
Fix duplicate import in tests

### DIFF
--- a/tests/test_dnstool.py
+++ b/tests/test_dnstool.py
@@ -1,4 +1,3 @@
-import sys
 import types
 import pytest
 


### PR DESCRIPTION
## Summary
- remove redundant import in `tests/test_dnstool.py`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*