### PR TITLE
Switch docs workflow to GitHub Actions pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,10 +12,14 @@ jobs:
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
-      - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@v1.29
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CONFIG_FILE: docs/mkdocs.yml
-          MKDOCS_BUILD_DIR: docs
+      - name: Build site
+        run: mkdocs build -f docs/mkdocs.yml
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v2
 


### PR DESCRIPTION
## Summary
- use GitHub maintained actions for deploying docs
- remove unused MKDOCS_BUILD_DIR setting

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*