### PR TITLE
Fix docs pipeline install mkdocs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,13 @@ jobs:
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs-material
       - name: Build site
         run: mkdocs build -f docs/mkdocs.yml
 


### PR DESCRIPTION
## Summary
- install MkDocs on the docs workflow so the site can build

## Testing
- `n/a`