### PR TITLE
Fix docs pipeline install mkdocs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,13 +12,20 @@ jobs:
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs-material
       - name: Build site
         run: mkdocs build -f docs/mkdocs.yml
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/site
+          path: site
 
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v2

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Thumbs.db
 *.log
 *.tmp
 .pytest_cache/
+site/

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -3,6 +3,7 @@ site_url: https://careyjames.github.io/dns-tool
 repo_url: https://github.com/careyjames/dns-tool
 repo_name: careyjames/dns-tool
 docs_dir: .
+site_dir: ../site
 nav:
   - Home: index.md
   - Installation and Setup: installation-and-setup.md


### PR DESCRIPTION
## Summary
- install MkDocs on the docs workflow so the site can build
- move the `site/` folder outside `docs` so MkDocs doesn't complain

## Testing
- `pip install mkdocs mkdocs-material` *(fails: no route to host)*