### PR TITLE
Fix MkDocs deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install mkdocs-material
+          pip install mkdocs mkdocs-material
       - name: Build site
         run: mkdocs build -f docs/mkdocs.yml
 
@@ -28,7 +28,10 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: site
+          name: github-pages
 
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v2
+        with:
+          artifact_name: github-pages
 


### PR DESCRIPTION
## Summary
- install mkdocs in CI
- upload `github-pages` artifact and deploy with that name

## Testing
- `pytest -q` *(fails: No module named pytest)*