### PR TITLE
Fix MkDocs deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,10 +7,16 @@ permissions:
   contents: write
   pages: write
   id-token: write
+concurrency:
+  group: pages
+  cancel-in-progress: true
 jobs:
   build:
     name: Deploy docs
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -20,15 +26,19 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install mkdocs-material
+          pip install mkdocs mkdocs-material
       - name: Build site
         run: mkdocs build -f docs/mkdocs.yml
-
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: site
-
+          name: github-pages
       - name: Deploy to GitHub Pages
+        id: deployment
         uses: actions/deploy-pages@v2
+        with:
+          artifact_name: github-pages
 


### PR DESCRIPTION
## Summary
- install mkdocs in CI
- upload `github-pages` artifact and deploy with that name
- set up Pages environment, configure Pages, and add concurrency

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement requests<3.0,>=2.31)*
- `pytest -q` *(fails: command not found)*