### PR TITLE
docs: mark CLI repo as legacy and route users to web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@
 >
 > 👉 https://dnstool.it-help.tech/
 >
-> The CLI remains available but is no longer the primary interface.
+> This repository is the **legacy CLI line**. Existing releases still work, but active feature development now happens in the web app.
 
 **DNS Tool** is a command-line utility for comprehensive DNS and email security auditing. It provides a one-stop solution to verify critical DNS records (DMARC, SPF, DKIM, DNSSEC, etc.) and offers real-time feedback on your domain’s configuration. Designed for network administrators, cybersecurity professionals, and IT engineers, DNS Tool helps prevent email spoofing (e.g., BEC attacks) and fortify your domain’s DNS infrastructure by giving an easy bird’s-eye view of all essential records.
+
+## Choosing the Right Version
+
+- Use the **web app** for the newest capabilities and easiest workflow: https://dnstool.it-help.tech/
+- Use this **CLI repository** when you specifically need local, offline, or script-driven checks.
+- Current feature inventory and product direction live in the web app codebase (`dnstoolweb/docs/FEATURE_INVENTORY.md`).
 
 ## Why DNS Tool Exists
 
@@ -48,9 +54,9 @@ Note: In the misconfigured domain example, it shows a ✅ by the TXT Records fou
 These outputs show how the DNS Tool provides clear indicators. For example, an ❌ “SPF: Missing” or ⚠️ “DMARC: p=none” warning stands out immediately.  
 This makes it easy to identify what needs fixing to improve your domain’s security posture.
 
-## Download and Installation
+## Legacy CLI Download and Installation
 
-DNS Tool is available as pre-compiled binaries for major platforms (Linux, macOS, Windows). Download the appropriate release for your system from the [GitHub Releases](../../releases) page. The table below shows the available builds:
+DNS Tool CLI is available as pre-compiled binaries for major platforms (Linux, macOS, Windows). Download the appropriate release for your system from the [GitHub Releases](../../releases) page. The table below shows the available builds:
 
 | Release Asset                     | Supported Systems                                                       |
 | --------------------------------- | ----------------------------------------------------------------------- |

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -2,6 +2,12 @@
 
 # Advanced Usage and Integration
 
+> **Legacy CLI advanced guide**
+>
+> This page applies to the command-line release line.
+>
+> For the current primary DNS Tool platform, use the web app: https://dnstool.it-help.tech/
+
 For power users and larger deployments, DNS Tool offers flexibility to integrate into scripts, CI pipelines, and other automation. It also provides flags to tweak its behavior for special scenarios. This section covers how to make the most of DNS Tool in advanced use cases, as well as performance considerations and troubleshooting tips.
 
 ## Integration & Automation

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,12 @@
 
 All notable changes to DNS Tool are documented here. This project adheres to semantic versioning.
 
+> **Legacy CLI release notes**
+>
+> This changelog tracks the command-line release line.
+>
+> New primary feature development is now in the web app: https://dnstool.it-help.tech/
+
 * **v1.2.3** – *Released 2025-05-17*
   **New Features:** Added support for BIMI and MTA-STS checks in the output (the tool now identifies BIMI records and validates MTA-STS policies). Improved DMARC feedback messages – the tool now explicitly warns when `p=none` and praises `p=reject` configurations.
   **Improvements:** Optimized interactive mode for faster start-up. Updated embedded dependencies to latest versions for security patches. Minor tweaks to color output for better readability on Windows.
@@ -17,4 +23,4 @@ All notable changes to DNS Tool are documented here. This project adheres to sem
 * **v1.2.1** – *Released 2025-03-01*
   Initial release of **DNS Tool (Python Edition)**. This version introduced the core functionality of the tool: interactive and batch modes, comprehensive DNS checks for NS, A, AAAA, MX, TXT, SPF, DKIM, DMARC, DNSSEC, PTR, etc., and integrated RDAP lookups for registrar info. The focus was on providing a unified output with clear indicators (✅/❌/⚠️) for each check. Packaged as a single-file executable via PyInstaller for easy distribution on Linux, macOS, and Windows.
 
-*(For a detailed history and commit-by-commit information, see the Git repository logs. Future release notes will continue to document new features, improvements, and fixes.)*
+*(For a detailed history and commit-by-commit information, see the Git repository logs. CLI updates may continue for compatibility and maintenance; primary feature evolution is in the web app.)*

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,16 @@
 
 # FAQ
 
+> **Legacy CLI FAQ**
+>
+> This FAQ applies to the command-line release line.
+>
+> For the current primary DNS Tool platform, use: https://dnstool.it-help.tech/
+
 Below are answers to some frequently asked questions about DNS Tool, covering usage, capabilities, and common scenarios.
+
+**Q: Is this repository still the primary DNS Tool product?**
+**A:** No. The web app at https://dnstool.it-help.tech/ is the primary and actively developed version. This repository remains available for CLI users who need local or script-based workflows.
 
 **Q: What do the symbols ✅, ❌, and ⚠️ mean in the output?**
 **A:** These symbols provide a quick assessment of each check’s result:
@@ -51,7 +60,7 @@ would query the two listed servers for all DNS lookups. This is useful if, say, 
 * It will alert if DMARC is missing or not at a strong policy.
 * It highlights if your MX setup might be problematic (no MX, or deprecated Google MX entries).
 * It notes optional improvements like DNSSEC not enabled, no CAA record, etc., as warnings.
-  In other words, a “clean” output (all ✅ and no ❌/⚠️) means your domain’s DNS is in great shape by current standards. If there are warnings, consider them recommendations for hardening your domain (for example, moving DMARC from none to reject, adding DNSSEC, etc.). The tool incorporates guidance from industry best practices – for instance, [our blog post on mastering DMARC/SPF/DKIM](https://www.it-help.tech/blog/defend-your-domain-master-dns-security-with-dmarc-spf-and-dkim) emphasizes an enforcement policy for DMARC; DNS Tool reflects that by warning on `p=none`. Always review the output messages in context; they often contain advice on why something is important.
+  In other words, a “clean” output (all ✅ and no ❌/⚠️) means your domain’s DNS is in great shape by current standards. If there are warnings, consider them recommendations for hardening your domain (for example, moving DMARC from none to reject, adding DNSSEC, etc.). The tool incorporates guidance from industry best practices - for instance, [our DMARC/SPF/DKIM guide](https://www.it-help.tech/blog/dns-security-best-practices/) emphasizes an enforcement policy for DMARC; DNS Tool reflects that by warning on `p=none`. Always review the output messages in context; they often contain advice on why something is important.
 
 **Q: Some of the checks aren’t applicable to my domain – can I ignore them?**
 **A:** Yes. DNS Tool is somewhat opinionated toward security best practices. If your domain doesn’t send email at all, seeing ❌ “No SPF” or “No DMARC” is technically fine (though consider adding them to prevent others from spoofing your unused domain). If you don’t operate a web service, “No A record” might be fine. The tool’s output is meant to be a helpful audit, not a strict pass/fail in every scenario. Use your knowledge of your domain’s purpose: for example, if you know a domain is only used for web, and you intentionally have no MX (so it shouldn’t receive email), you can ignore the “No MX” error – but you might still want an SPF/DMARC of `v=spf1 -all` and `p=reject` to nullify email misuse. Ultimately, treat the tool as a knowledgeable advisor: most ❌ need fixing, most ⚠️ deserve improvement, but you’re the final judge of what’s relevant.
@@ -60,6 +69,6 @@ would query the two listed servers for all DNS lookups. This is useful if, say, 
 **A:** Yes. It’s a read-only tool – it only performs DNS queries (the same kind your computer does when visiting a website or sending email) and RDAP/WHOIS lookups. It doesn’t make any changes to DNS. Checking someone else’s domain with DNS Tool is equivalent to querying their DNS records publicly, which is normal and allowed. All the data retrieved is public information by design of DNS. The tool’s queries are also unlikely to trigger any security alarms; at worst, RDAP queries might be rate-limited if you do them in huge volume. We designed DNS Tool to be non-intrusive and network-friendly.
 
 **Q: Can I add or suggest new features?**
-**A:** Definitely. DNS and email security evolve, and we welcome contributions. If you have an idea (for example, checking for a new record type, or supporting JSON output, or an interactive GUI), feel free to open an issue or a pull request on the GitHub repository. This project is open source (Apache 2.0 licensed) and thrives on community feedback. Whether it’s a bug report, a feature request, or a code contribution, we’d love to hear from you.
+**A:** Definitely. DNS and email security evolve, and we welcome contributions. If you have an idea, feel free to open an issue or a pull request on this repository. Please note that major product evolution now happens in the web platform, so some feature requests may be implemented there first.
 
 Hopefully this FAQ answers most questions you’ll have. If you need more help, check out the repository README or open a discussion with the community. Happy DNS exploring!

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,12 @@
 
 # Introduction to DNS Tool
 
+> **Legacy CLI documentation**
+>
+> This docs set covers the DNS Tool command-line release line.
+>
+> For the actively developed version and current feature set, use the web app: https://dnstool.it-help.tech/
+
 **DNS Tool** is an all-in-one command-line utility for checking critical DNS records like **DMARC**, **SPF**, **DKIM**, **DNSSEC**, and more. It gives you a bird’s-eye view of a domain’s DNS and email security posture, helping strengthen defenses against phishing and spoofing. Whether you’re a system administrator or a security analyst, DNS Tool streamlines the process of validating DNS configurations across your domains.
 
 ## Main Features
@@ -11,6 +17,8 @@
 * **Clear, Color-Coded Output:** Results use intuitive symbols (✅ pass, ❌ fail, ⚠️ warning) and colors to highlight issues and recommendations. You can immediately spot misconfigurations, missing records, or weak policies without digging through verbose data.
 
 ## Quick Start
+
+If you do not need local CLI execution, use the web app directly (no install required): https://dnstool.it-help.tech/
 
 ### Installation
 

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -2,6 +2,12 @@
 
 # Installation and Setup
 
+> **Legacy CLI install guide**
+>
+> This page is for the command-line release line.
+>
+> For the current primary experience, use the web app (no install): https://dnstool.it-help.tech/
+
 Welcome to the **DNS Tool** installation guide. Follow the steps below to get DNS Tool up and running on your platform. Precompiled binaries are available for Linux, macOS, and Windows – no additional dependencies required.
 
 ## Linux

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: DNS Tool Documentation
+site_name: DNS Tool Legacy CLI Documentation
 site_url: https://careyjames.github.io/dns-tool
 repo_url: https://github.com/careyjames/dns-tool
 repo_name: careyjames/dns-tool

--- a/docs/records.md
+++ b/docs/records.md
@@ -2,6 +2,12 @@
 
 # DNS Checks Explained
 
+> **Legacy CLI reference**
+>
+> This record-check behavior describes the command-line release line.
+>
+> For the actively developed DNS Tool platform and current capabilities, use: https://dnstool.it-help.tech/
+
 DNS Tool performs a variety of checks on different DNS records and related services. This section explains each category of checks, what they mean, and why they matter for security. Understanding the output will help you interpret DNS Tool’s findings and take the right action.
 
 ## Email Security Records: SPF, DKIM, DMARC, and BIMI
@@ -24,7 +30,7 @@ DNS Tool performs a variety of checks on different DNS records and related servi
   * **p=quarantine:** This tells receivers to treat failing emails with suspicion (usually send to spam). DNS Tool will mark this as a ✅ but note that quarantine is good, though not as strong as reject.
   * **p=reject:** This is the strongest policy, instructing receivers to outright reject emails that fail SPF/DKIM checks. DNS Tool gives a ✅ and a message like “DMARC p=reject => Great anti-spoof!”, confirming you’re at an optimal security stance.
   * Any other policy or syntax issue, the tool will simply show the DMARC record and indicate it found one, without a specific icon (or with a generic ✅ if the record is present but non-standard).
-* *Why it matters:* DMARC is your domain’s last line of defense against spoofed emails. Without DMARC, anyone can send email pretending to be your domain and you’ll only know if you happen to see the abuse. With DMARC in “reject” or “quarantine”, recipients will actually block or flag those illegitimate emails. Industry best practices and regulatory bodies (like CISA) strongly recommend moving to **p=reject** as soon as you’re confident your mail streams are properly authenticated. In our blog post [*Defend Your Domain: Master DNS Security with DMARC, SPF, and DKIM*](https://www.it-help.tech/blog/defend-your-domain-master-dns-security-with-dmarc-spf-and-dkim), we outline how organizations should start with monitoring (p=none) and gradually step up to enforcement (p=quarantine, then p=reject) – DNS Tool makes it easy to verify each step of that journey.
+* *Why it matters:* DMARC is your domain’s last line of defense against spoofed emails. Without DMARC, anyone can send email pretending to be your domain and you’ll only know if you happen to see the abuse. With DMARC in “reject” or “quarantine”, recipients will actually block or flag those illegitimate emails. Industry best practices and regulatory bodies (like CISA) strongly recommend moving to **p=reject** as soon as you’re confident your mail streams are properly authenticated. In our blog post [*DNS Security Best Practices: Defend Your Domain with DMARC, SPF & DKIM*](https://www.it-help.tech/blog/dns-security-best-practices/), we outline how organizations should start with monitoring (p=none) and gradually step up to enforcement (p=quarantine, then p=reject) - DNS Tool makes it easy to verify each step of that journey.
 
 **BIMI (Brand Indicators for Message Identification):** BIMI is an emerging standard that allows you to publish your brand’s logo in DNS so that supporting email clients can display it alongside authenticated emails from your domain. BIMI isn’t a security control per se, but it *requires* that you have a solid DMARC policy in place (usually p=reject) before you can use it, so it’s a good “bonus” indicator of strong email security posture.
 

--- a/docs/usage-and-examples.md
+++ b/docs/usage-and-examples.md
@@ -1,5 +1,11 @@
 # Usage and Examples
 
+> **Legacy CLI usage guide**
+>
+> This page documents the command-line workflow.
+>
+> For the actively developed DNS Tool experience, use the web app: https://dnstool.it-help.tech/
+
 This guide will show you how to get started with DNS Tool. It will showcase how to use the tool in both interactive and batch modes, with example commands and output descriptions.
 
 ## Interactive Mode 🌟

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -1,1 +1,7 @@
-Last known-good version before the PyInstaller refactor.
+# Legacy Snapshot
+
+This folder contains the last known-good historical version before the PyInstaller refactor.
+
+It is retained for reference only and is not the primary release path.
+
+Current primary DNS Tool platform: https://dnstool.it-help.tech/


### PR DESCRIPTION
## Summary
- mark this repository as the legacy CLI line while keeping releases usable
- add consistent pointers to https://dnstool.it-help.tech/ across README and docs entry points
- rename docs site label to legacy CLI documentation
- refresh outdated blog links to the current DNS security guide

## Scope
- documentation-only changes
- no changes to CLI behavior or feature implementation